### PR TITLE
Show only approved vendor items

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -5,7 +5,8 @@ class CategoriesController < ApplicationController
   end
 
   def show
+    @per_page = params[:per_page] || 15
     @category = Category.find_by(slug: params[:id])
-    @items = @category.items
+    @items = @category.items.from_approved_vendors.paginate(:per_page => @per_page, :page => params[:page])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,6 @@
 class ItemsController < ApplicationController
   def index
     @per_page = params[:per_page] || 15
-    approved_vendor_items = Item.joins(:vendor).where(vendors: {status: "approved"})
-    @items = approved_vendor_items.paginate(:per_page => @per_page, :page => params[:page])
+    @items = Item.from_approved_vendors.paginate(:per_page => @per_page, :page => params[:page])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   def index
     @per_page = params[:per_page] || 15
-    @items = Item.paginate(:per_page => @per_page, :page => params[:page])
+    approved_vendor_items = Item.joins(:vendor).where(vendors: {status: "approved"})
+    @items = approved_vendor_items.paginate(:per_page => @per_page, :page => params[:page])
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,4 +25,8 @@ class Item < ActiveRecord::Base
     self.where("name ILIKE ? or description ILIKE ?", query, query)
   end
 
+  def self.from_approved_vendors
+    self.joins(:vendor).where(vendors: {status: "approved"})
+  end
+
 end

--- a/app/views/vendor/items/show.html.erb
+++ b/app/views/vendor/items/show.html.erb
@@ -7,7 +7,7 @@
     <div class="col-md-8" id="item_details">
       <h2><%= @item.name %></h2>
       <p><%= @item.description %></p>
-      <p> Vendor - <%= link_to @item.vendor.name, vendor_path, class: "text-muted order" %> </p>
+      <p> Vendor - <%= link_to @item.vendor.name, vendor_show_path(@item.vendor.slug), class: "text-muted order" %> </p>
       <p> Category - <%= link_to @item.category.name, category_path(@item.category), class: "text-muted order" %> </p>
       <h5>$<%= @item.price %></h5>
 


### PR DESCRIPTION
Previously, the items index page was showing items for vendors that had not yet been approved.
This change only shows approved vendor items.
Fixed vendor item show page link back to the vendor
